### PR TITLE
Fix/#119

### DIFF
--- a/src/main/generated/com/letsintern/letsintern/domain/application/domain/QApplication.java
+++ b/src/main/generated/com/letsintern/letsintern/domain/application/domain/QApplication.java
@@ -30,6 +30,8 @@ public class QApplication extends EntityPathBase<Application> {
 
     public final EnumPath<ApplicationAttendance> attendance = createEnum("attendance", ApplicationAttendance.class);
 
+    public final StringPath couponCode = createString("couponCode");
+
     public final StringPath createdAt = createString("createdAt");
 
     public final StringPath email = createString("email");
@@ -57,6 +59,8 @@ public class QApplication extends EntityPathBase<Application> {
     public final NumberPath<Long> reviewId = createNumber("reviewId", Long.class);
 
     public final EnumPath<ApplicationStatus> status = createEnum("status", ApplicationStatus.class);
+
+    public final NumberPath<Integer> totalFee = createNumber("totalFee", Integer.class);
 
     public final EnumPath<ApplicationType> type = createEnum("type", ApplicationType.class);
 

--- a/src/main/generated/com/letsintern/letsintern/domain/program/domain/QProgram.java
+++ b/src/main/generated/com/letsintern/letsintern/domain/program/domain/QProgram.java
@@ -32,6 +32,8 @@ public class QProgram extends EntityPathBase<Program> {
 
     public final StringPath contents = createString("contents");
 
+    public final NumberPath<Integer> discountValue = createNumber("discountValue", Integer.class);
+
     public final DateTimePath<java.time.LocalDateTime> dueDate = createDateTime("dueDate", java.time.LocalDateTime.class);
 
     public final DateTimePath<java.time.LocalDateTime> endDate = createDateTime("endDate", java.time.LocalDateTime.class);

--- a/src/main/java/com/letsintern/letsintern/domain/application/helper/ApplicationHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/application/helper/ApplicationHelper.java
@@ -19,6 +19,7 @@ import com.letsintern.letsintern.domain.program.exception.ProgramNotFound;
 import com.letsintern.letsintern.domain.program.repository.ProgramRepository;
 import com.letsintern.letsintern.domain.program.vo.ProgramEmailVo;
 import com.letsintern.letsintern.domain.user.domain.User;
+import com.letsintern.letsintern.domain.user.domain.UserRole;
 import com.letsintern.letsintern.global.common.util.EmailUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -231,5 +232,12 @@ public class ApplicationHelper {
     public void validateHasUserAccountInfo(ApplicationCreateDTO applicationCreateDTO) {
         if (Objects.isNull(applicationCreateDTO.getAccountType()) || Objects.isNull(applicationCreateDTO.getAccountNumber()))
             throw ApplicationUserBadRequestAccount.EXCEPTION;
+    }
+
+    public void validateIsChallengeParticipant(UserRole userRole, Long programId, Long userId) {
+        if(!userRole.equals(UserRole.ROLE_ADMIN)) {
+            final Application application = applicationRepository.findByProgramIdAndUserId(programId, userId);
+            if (application == null) throw ApplicationNotFound.EXCEPTION;
+        }
     }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
@@ -88,6 +88,7 @@ public class AttendanceHelper {
         if(attendanceAdminUpdateDTO.getComments() != null) attendance.setComments(attendanceAdminUpdateDTO.getComments());
         if(attendanceAdminUpdateDTO.getIsRefunded() != null) attendance.setIsRefunded(attendanceAdminUpdateDTO.getIsRefunded());
 
+        attendanceRepository.save(attendance);
         return attendance.getId();
     }
 

--- a/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
@@ -69,6 +69,10 @@ public class AttendanceHelper {
         return attendance.getId();
     }
 
+    public Integer getYesterdayHeadCount(Long programId, Integer missionTh, AttendanceStatus attendanceStatus, AttendanceResult attendanceResult) {
+        return attendanceRepository.countAllByMissionProgramIdAndMissionThAndStatusAndResult(programId, missionTh, attendanceStatus, attendanceResult);
+    }
+
     public Page<AttendanceAdminVo> getAttendanceAdminList(Long missionId, Pageable pageable) {
         return attendanceRepository.getAttendanceAdminVos(missionId, pageable);
     }

--- a/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
@@ -1,5 +1,7 @@
 package com.letsintern.letsintern.domain.mission.helper;
 
+import com.letsintern.letsintern.domain.attendance.domain.AttendanceResult;
+import com.letsintern.letsintern.domain.attendance.domain.AttendanceStatus;
 import com.letsintern.letsintern.domain.attendance.repository.AttendanceRepository;
 import com.letsintern.letsintern.domain.contents.domain.Contents;
 import com.letsintern.letsintern.domain.contents.domain.ContentsTopic;
@@ -179,4 +181,13 @@ public class MissionHelper {
         return missionRepository.getMissionMyDashboardYetVo(missionId).orElseThrow(() -> MissionNotFound.EXCEPTION);
     }
 
+    public int getCurrentRefund(List<MissionDashboardListVo> missionList) {
+        int currentRefund = 0;
+        for(MissionDashboardListVo mission : missionList) {
+            if(mission.getMissionType().equals(MissionType.REFUND) && mission.getAttendanceStatus().equals(AttendanceStatus.PRESENT) && !mission.getAttendanceResult().equals(AttendanceResult.WRONG)) {
+                currentRefund += mission.getMissionRefund();
+            }
+        }
+        return currentRefund;
+    }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/program/dto/response/ProgramDashboardResponse.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/dto/response/ProgramDashboardResponse.java
@@ -1,8 +1,5 @@
 package com.letsintern.letsintern.domain.program.dto.response;
 
-import com.letsintern.letsintern.domain.attendance.domain.AttendanceResult;
-import com.letsintern.letsintern.domain.attendance.domain.AttendanceStatus;
-import com.letsintern.letsintern.domain.mission.domain.MissionType;
 import com.letsintern.letsintern.domain.mission.vo.MissionDashboardListVo;
 import com.letsintern.letsintern.domain.mission.vo.MissionDashboardVo;
 import com.letsintern.letsintern.domain.notice.domain.Notice;
@@ -35,14 +32,7 @@ public class ProgramDashboardResponse {
 
     @Builder
     private ProgramDashboardResponse(String userName, MissionDashboardVo dailyMission, Page<Notice> noticeList, List<MissionDashboardListVo> missionList,
-                                     Integer totalRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
-        int currentRefund = 0;
-        for(MissionDashboardListVo mission : missionList) {
-            if(mission.getMissionType().equals(MissionType.REFUND) && mission.getAttendanceStatus().equals(AttendanceStatus.PRESENT) && !mission.getAttendanceResult().equals(AttendanceResult.WRONG)) {
-                currentRefund += mission.getMissionRefund();
-            }
-        }
-
+                                     Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
         this.userName = userName;
         this.dailyMission = dailyMission;
         this.noticeList = (noticeList.hasContent()) ? noticeList.getContent() : new ArrayList<>();
@@ -50,18 +40,19 @@ public class ProgramDashboardResponse {
         this.currentRefund = currentRefund;
         this.totalRefund = totalRefund;
         this.finalHeadCount = finalHeadCount;
-        if(dailyMission != null && (dailyMission.getTh() >= 2 && dailyMission.getTh() <= 14)) this.yesterdayHeadCount = yesterdayHeadCount;
+        this.yesterdayHeadCount = yesterdayHeadCount;
         this.isDone = isDone;
     }
 
     public static ProgramDashboardResponse of(String userName, MissionDashboardVo dailyMission, Page<Notice> noticeList, List<MissionDashboardListVo> missionList,
-                                              Integer totalRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
+                                              Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
         return ProgramDashboardResponse.builder()
                 .userName(userName)
                 .dailyMission(dailyMission)
                 .noticeList(noticeList)
                 .missionList(missionList)
                 .totalRefund(totalRefund)
+                .currentRefund(currentRefund)
                 .finalHeadCount(finalHeadCount)
                 .yesterdayHeadCount(yesterdayHeadCount)
                 .isDone(isDone)

--- a/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
@@ -48,10 +48,16 @@ public class ProgramHelper {
     private final ApplicationHelper applicationHelper;
     private final EmailUtils emailUtils;
 
-    public int generateRandomNumber() {
+    public String generateRandomNumber() {
         SecureRandom secureRandom = new SecureRandom();
         int upperLimit = (int) Math.pow(10, RANDOM_NUMBER_LENGTH);
-        return secureRandom.nextInt(upperLimit);
+
+        String mentorPassword = String.valueOf(secureRandom.nextInt(upperLimit));
+        while(mentorPassword.length() < RANDOM_NUMBER_LENGTH) {
+            mentorPassword = "0" + mentorPassword;
+        }
+
+        return mentorPassword;
     }
 
     public String getProgramMentorPassword(Long programId) {

--- a/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
@@ -120,14 +120,6 @@ public class ProgramHelper {
         return applicationRepository.findAllProgramByUserId(userId, pageable);
     }
 
-    public Program getExistingProgram(Long programId) {
-        Program program = programRepository.findById(programId)
-                .orElseThrow(() -> {
-                    throw ProgramNotFound.EXCEPTION;
-                });
-        return program;
-    }
-
     public void saveFinalHeadCount(Long programId) {
         Program program = programRepository.findById(programId).orElseThrow(() -> ProgramNotFound.EXCEPTION);
         program.setFinalHeadCount(applicationRepository.countAllByProgramIdAndStatus(programId, ApplicationStatus.IN_PROGRESS));

--- a/src/main/java/com/letsintern/letsintern/domain/program/mapper/ProgramMapper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/mapper/ProgramMapper.java
@@ -54,8 +54,8 @@ public class ProgramMapper {
     }
 
     public ProgramDashboardResponse toProgramDashboardResponse(String userName, MissionDashboardVo dailyMission, Page<Notice> noticeList, List<MissionDashboardListVo> missionList,
-                                                               Integer totalRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
-        return ProgramDashboardResponse.of(userName, dailyMission, noticeList, missionList, totalRefund, finalHeadCount, yesterdayHeadCount, isDone);
+                                                               Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
+        return ProgramDashboardResponse.of(userName, dailyMission, noticeList, missionList, totalRefund, currentRefund, finalHeadCount, yesterdayHeadCount, isDone);
     }
 
     public ProgramMyDashboardResponse toProgramMyDashboardResponse(MissionMyDashboardVo dailyMission, List<MissionDashboardListVo> missionList, Boolean isDone) {

--- a/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramService.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramService.java
@@ -220,8 +220,7 @@ public class ProgramService {
     private String createMentorPasswordForLetsChatType(ProgramCreateRequestDTO programCreateRequestDTO) {
         String mentorPassword = null;
         if (programCreateRequestDTO.getType().equals(ProgramType.LETS_CHAT)) {
-            int randomNumber = programHelper.generateRandomNumber();
-            mentorPassword = String.valueOf(randomNumber);
+            mentorPassword = programHelper.generateRandomNumber();
         }
         return mentorPassword;
     }

--- a/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramService.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramService.java
@@ -7,9 +7,12 @@ import com.letsintern.letsintern.domain.application.helper.ApplicationHelper;
 import com.letsintern.letsintern.domain.application.repository.ApplicationRepository;
 import com.letsintern.letsintern.domain.attendance.domain.AttendanceResult;
 import com.letsintern.letsintern.domain.attendance.domain.AttendanceStatus;
-import com.letsintern.letsintern.domain.attendance.repository.AttendanceRepository;
+import com.letsintern.letsintern.domain.attendance.helper.AttendanceHelper;
+import com.letsintern.letsintern.domain.mission.domain.MissionType;
 import com.letsintern.letsintern.domain.mission.helper.MissionHelper;
+import com.letsintern.letsintern.domain.mission.vo.MissionDashboardListVo;
 import com.letsintern.letsintern.domain.mission.vo.MissionDashboardVo;
+import com.letsintern.letsintern.domain.notice.domain.Notice;
 import com.letsintern.letsintern.domain.notice.helper.NoticeHelper;
 import com.letsintern.letsintern.domain.program.domain.*;
 import com.letsintern.letsintern.domain.program.dto.request.LetsChatMentorPasswordRequestDTO;
@@ -26,11 +29,13 @@ import com.letsintern.letsintern.domain.user.domain.User;
 import com.letsintern.letsintern.domain.user.domain.UserRole;
 import com.letsintern.letsintern.global.config.user.PrincipalDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -45,9 +50,9 @@ public class ProgramService {
     private final ApplicationHelper applicationHelper;
     private final ApplicationRepository applicationRepository;
     private final MissionHelper missionHelper;
+    private final AttendanceHelper attendanceHelper;
     private final NoticeHelper noticeHelper;
     private final ZoomMeetingApiHelper zoomMeetingApiHelper;
-    private final AttendanceRepository attendanceRepository;
 
     public Long getDoneProgramCount() {
         return programRepository.countByStatusEquals(ProgramStatus.DONE);
@@ -74,6 +79,10 @@ public class ProgramService {
         /* program entity 생성 및 저장 */
         Program savedProgram = createProgramAndSave(programCreateRequestDTO, zoomMeetingCreateResponse, mentorPassword);
         return programMapper.toProgramIdResponseDTO(savedProgram.getId());
+    }
+
+    public Program getProgram(Long programId) {
+        return programHelper.findProgramOrThrow(programId);
     }
 
     @Transactional
@@ -112,10 +121,6 @@ public class ProgramService {
         }
     }
 
-    public Program getProgram(Long programId) {
-        return programHelper.getExistingProgram(programId);
-    }
-
     public void deleteProgram(Long programId) {
         Program program = programRepository.findById(programId)
                 .orElseThrow(() -> {
@@ -139,25 +144,33 @@ public class ProgramService {
 
     @Transactional(readOnly = true)
     public ProgramDashboardResponse getProgramDashboard(Long programId, PrincipalDetails principalDetails, Pageable pageable) {
-        final Program program = programRepository.findById(programId).orElseThrow(() -> ProgramNotFound.EXCEPTION);
+        final Program program = programHelper.findProgramOrThrow(programId);
         final User user = principalDetails.getUser();
-        if (!user.getRole().equals(UserRole.ROLE_ADMIN)) {
-            final Application application = applicationRepository.findByProgramIdAndUserId(programId, user.getId());
-            if (application == null) throw ApplicationNotFound.EXCEPTION;
-        }
+        applicationHelper.validateIsChallengeParticipant(user.getRole(), program.getId(), user.getId());
 
-        MissionDashboardVo dailyMission = missionHelper.getDailyMission(program.getId(), program.getStartDate());
-        Integer yesterdayHeadCount = (dailyMission == null) ? null : attendanceRepository.countAllByMissionProgramIdAndMissionThAndStatusAndResult(programId, dailyMission.getTh() - 1, AttendanceStatus.PRESENT, AttendanceResult.PASS);
+        /* 챌린지 종료 여부 */
+        boolean isDoneProgram = program.getEndDate().isBefore(LocalDateTime.now());
+        /* 데일리 미션 */
+        MissionDashboardVo dailyMission = (isDoneProgram) ? null : missionHelper.getDailyMission(program.getId(), program.getStartDate());
+        /* 공지사항 목록 */
+        Page<Notice> noticeList = noticeHelper.getNoticeList(program.getId(), pageable);
+        /* 전체 미션, 출석 현황 */
+        List<MissionDashboardListVo> missionList = missionHelper.getMissionDashboardList(program.getId(), user.getId());
+        /* 현재까지 환급금 */
+        Integer currentRefund = (isDoneProgram) ? 0 : missionHelper.getCurrentRefund(missionList);
+        /* 어제 미션을 정상 제출한 인원수 */
+        Integer yesterdayHeadCount = (isDoneProgram) ? null : attendanceHelper.getYesterdayHeadCount(program.getId(), dailyMission.getTh() - 1, AttendanceStatus.PRESENT, AttendanceResult.PASS);
 
         return programMapper.toProgramDashboardResponse(
                 user.getName(),
                 dailyMission,
-                noticeHelper.getNoticeList(programId, pageable),
-                missionHelper.getMissionDashboardList(programId, user.getId()),
+                noticeList,
+                missionList,
                 program.getFeeRefund(),
+                currentRefund,
                 program.getFinalHeadCount(),
                 yesterdayHeadCount,
-                program.getEndDate().isBefore(LocalDateTime.now())
+                isDoneProgram
         );
     }
 
@@ -165,10 +178,7 @@ public class ProgramService {
     public ProgramMyDashboardResponse getProgramMyDashboard(Long programId, PrincipalDetails principalDetails) {
         final Program program = programRepository.findById(programId).orElseThrow(() -> ProgramNotFound.EXCEPTION);
         final User user = principalDetails.getUser();
-        if (!user.getRole().equals(UserRole.ROLE_ADMIN)) {
-            final Application application = applicationRepository.findByProgramIdAndUserId(programId, user.getId());
-            if (application == null) throw ApplicationNotFound.EXCEPTION;
-        }
+        applicationHelper.validateIsChallengeParticipant(user.getRole(), program.getId(), user.getId());
 
         return programMapper.toProgramMyDashboardResponse(
                 missionHelper.getDailyMissionDetail(program.getId(), program.getStartDate(), user.getId()),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
 #        show_sql: true

--- a/src/test/java/com/letsintern/letsintern/domain/program/helper/ProgramHelperMentorPasswordTest.java
+++ b/src/test/java/com/letsintern/letsintern/domain/program/helper/ProgramHelperMentorPasswordTest.java
@@ -1,0 +1,54 @@
+package com.letsintern.letsintern.domain.program.helper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.security.SecureRandom;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProgramHelperMentorPasswordTest {
+
+    @Test
+    @DisplayName("랜덤 비밀번호 생성 자릿수 테스트 (기존)")
+    void generateRandomNumber_previous() {
+        // given
+        int RANDOM_NUMBER_LENGTH = 4;
+        int n = 100000;
+
+        while(n-- > 0) {
+            // when
+            SecureRandom secureRandom = new SecureRandom();
+            int upperLimit = (int) Math.pow(10, RANDOM_NUMBER_LENGTH);
+            int mentorPassword = secureRandom.nextInt(upperLimit);
+
+            // then
+            System.out.println(mentorPassword);
+            assertEquals(RANDOM_NUMBER_LENGTH, String.valueOf(mentorPassword).length());
+        }
+
+    }
+
+    @Test
+    @DisplayName("랜덤 비밀번호 생성 자릿수 테스트 (변경 후)")
+    void generateRandomNumber() {
+        // given
+        int RANDOM_NUMBER_LENGTH = 4;
+        int n = 100000;
+
+        while(n-- > 0) {
+            // when
+            SecureRandom secureRandom = new SecureRandom();
+            int upperLimit = (int) Math.pow(10, RANDOM_NUMBER_LENGTH);
+            String mentorPassword = String.valueOf(secureRandom.nextInt(upperLimit));
+
+            while(mentorPassword.length() < RANDOM_NUMBER_LENGTH) {
+                mentorPassword = "0" + mentorPassword;
+            }
+
+            // then
+            System.out.println(mentorPassword);
+            assertEquals(RANDOM_NUMBER_LENGTH, mentorPassword.length());
+        }
+    }
+}


### PR DESCRIPTION
## 🟪 관련 이슈

- close #119 

## 🟪 작업 내용

- [x] 렛츠챗 멘토 비밀번호 자릿수 일정하게 변경
- [x] Attendance 수정 직후 계좌 다운로드 시 직전 수정 Attendance 누락 이슈 해결
- [x] 기간이 지난 챌린지 관련 ProgramService 수정

## 🟪 PR Point 

**1) 기존의 렛츠챗 랜덤 비밀번호 생성 로직은 최대 4자리수로 설정되어 있는 문제 발생**
  - 범위를 min(1000) ~ max(9999)로 지정하는 방법도 있었으나, 0000 ~ 0999 범위는 누락되는 한계 있음
  - 따라서 기존 방식을 이용하되, 4자리수 미만일 경우 0을 채워 4자리로 맞추는 방식으로 수정

**2) 챌린지에서 Attendance 출석 상태를 '확인 완료'로 업데이트한 직후 환급 대상자 계좌 목록 API 호출 시, 직전에 업데이트한 Attendance의 대상가 누락되는 이슈 발생**
  - 출석 상태의 Update가 @Transactional에 묶여있어서 쓰기 지연 문제가 발생한 것
  - @Transactional을 제거하고 바로 DB에 반영하게끔 수정

**3) 종료된 챌린지의 경우 누적 환급 금액을 보여주지 않기로 결정됨**
  - 챌린지 종료 여부에 따라 환급 금액 계산 로직 분기처리 
  - 챌린지 유저 대시보드 API의 Service단 정리
