### PR TITLE
Refactor/#146

### DIFF
--- a/src/main/java/com/letsintern/letsintern/domain/application/repository/ApplicationRepositoryImpl.java
+++ b/src/main/java/com/letsintern/letsintern/domain/application/repository/ApplicationRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.letsintern.letsintern.domain.application.vo.ApplicationEntireDashboar
 import com.letsintern.letsintern.domain.application.vo.ApplicationVo;
 import com.letsintern.letsintern.domain.payment.domain.FeeType;
 import com.letsintern.letsintern.domain.program.domain.ProgramStatus;
+import com.letsintern.letsintern.domain.program.domain.QChallenge;
 import com.letsintern.letsintern.domain.program.vo.program.UserProgramVo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
@@ -27,6 +28,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static com.letsintern.letsintern.domain.program.domain.QChallenge.challenge;
+import static com.letsintern.letsintern.domain.application.domain.QApplication.application;
 
 @Repository
 @RequiredArgsConstructor
@@ -318,6 +322,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
                     .where(
                             qApplication.program.id.eq(programId),
                             qApplication.status.in(ApplicationStatus.IN_PROGRESS, ApplicationStatus.DONE));
+
         } else if (applicationWishJob.equals(ApplicationWishJob.MARKETING_ALL) || applicationWishJob.equals(ApplicationWishJob.DEVELOPMENT_ALL)) {
             applicationEntireDashboardVos = jpaQueryFactory
                     .select(Projections.constructor(ApplicationEntireDashboardVo.class,
@@ -342,7 +347,7 @@ public class ApplicationRepositoryImpl implements ApplicationRepositoryCustom {
                     .from(qApplication)
                     .where(
                             qApplication.program.id.eq(programId),
-                            qApplication.program.topic.eq(applicationWishJob.getChallengeTopic()),
+                            qApplication.program.as(QChallenge.class).topic.eq(applicationWishJob.getChallengeTopic()),
                             qApplication.status.in(ApplicationStatus.IN_PROGRESS, ApplicationStatus.DONE));
         } else {
             applicationEntireDashboardVos = jpaQueryFactory

--- a/src/main/java/com/letsintern/letsintern/domain/banner/service/BannerServiceFactoryConfig.java
+++ b/src/main/java/com/letsintern/letsintern/domain/banner/service/BannerServiceFactoryConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class BannerServiceFactoryConfig {
     @Bean
-    public ServiceLocatorFactoryBean serviceLocatorFactoryBean() {
+    public ServiceLocatorFactoryBean bannerServiceLocatorFactoryBean() {
         ServiceLocatorFactoryBean factoryBean = new ServiceLocatorFactoryBean();
         factoryBean.setServiceLocatorInterface(BannerServiceFactory.class);
         return factoryBean;

--- a/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.letsintern.letsintern.domain.attendance.domain.QAttendance;
 import com.letsintern.letsintern.domain.contents.domain.QContents;
 import com.letsintern.letsintern.domain.mission.domain.QMission;
 import com.letsintern.letsintern.domain.mission.vo.*;
+import com.letsintern.letsintern.domain.program.domain.QChallenge;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -42,7 +43,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                         qContents.topic,
                         qMission.attendanceCount,
                         qMission.lateAttendanceCount,
-                        qMission.program.finalHeadCount))
+                        qMission.program.as(QChallenge.class).finalHeadCount))
                 .from(qMission)
                 .leftJoin(qContents)
                 .on(

--- a/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
@@ -83,7 +83,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                         qMission.startDate,
                         qMission.endDate,
                         qMission.refund,
-                        qMission.program.feeRefund,
+                        qMission.program.payment.feeRefund,
                         qEssentialContents.topic,
                         qAdditionalContents.topic,
                         qLimitedContents.topic))

--- a/src/main/java/com/letsintern/letsintern/domain/program/ProgramController.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/ProgramController.java
@@ -3,6 +3,7 @@ package com.letsintern.letsintern.domain.program;
 import com.letsintern.letsintern.domain.application.domain.ApplicationWishJob;
 import com.letsintern.letsintern.domain.program.domain.MailType;
 import com.letsintern.letsintern.domain.program.domain.ProgramRequestType;
+import com.letsintern.letsintern.domain.program.domain.ProgramType;
 import com.letsintern.letsintern.domain.program.dto.request.BaseProgramRequestDto;
 import com.letsintern.letsintern.domain.program.dto.request.LetsChatMentorPasswordDto;
 import com.letsintern.letsintern.domain.program.dto.response.*;
@@ -155,11 +156,11 @@ public class ProgramController {
         return programSpecificService.getProgramEntireDashboard(programId, applicationWishJob, principalDetails, pageable);
     }
 
-    @Operation(summary = "어드민 프로그램 목록 (전체, 타입, 타입&기수)")
+    @Operation(summary = "어드민 프로그램 목록 (전체, 타입, 타입 & 기수)")
     @GetMapping("/admin")
-    public ResponseEntity<ProgramListResponseDto<?>> getAdminProgramList(@RequestParam(required = false) String type,
+    public ResponseEntity<ProgramListResponseDto<?>> getAdminProgramList(@RequestParam(required = false) ProgramRequestType type,
                                                                          @RequestParam(required = false) Integer th,
                                                                          @PageableDefault(size = 20) Pageable pageable) {
-        return programSpecificService.getProgramAdminList(type, th, pageable);
+        return ResponseEntity.ok(programSpecificService.getProgramAdminList(type, th, pageable));
     }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/program/domain/Challenge.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/domain/Challenge.java
@@ -33,10 +33,10 @@ public class Challenge extends Program {
     private String openKakaoLink;
     @Column(length = 10)
     private String openKakaoPassword;
-    @OneToMany(mappedBy = "challenge", orphanRemoval = true)
+    @OneToMany(mappedBy = "program", orphanRemoval = true)
     @Builder.Default
     private List<Mission> missionList = new ArrayList<>();
-    @OneToMany(mappedBy = "challenge", orphanRemoval = true)
+    @OneToMany(mappedBy = "program", orphanRemoval = true)
     @Builder.Default
     private List<Notice> noticeList = new ArrayList<>();
 

--- a/src/main/java/com/letsintern/letsintern/domain/program/domain/LetsChat.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/domain/LetsChat.java
@@ -15,7 +15,6 @@ import static com.letsintern.letsintern.global.utils.EntityUpdateValueUtils.upda
 public class LetsChat extends Program {
     @Column(length = 10, nullable = false)
     @Convert(converter = MailStatusConverter.class)
-    @Builder.Default
     private MailStatus mailStatus = MailStatus.YET;
     @Column(nullable = false)
     private String mentorPassword;

--- a/src/main/java/com/letsintern/letsintern/domain/program/domain/Program.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/domain/Program.java
@@ -45,13 +45,10 @@ public abstract class Program {
     @Column(nullable = false)
     private LocalDateTime endDate;
     @Column(nullable = false)
-    @Builder.Default
     private Integer applicationCount = 0;
     @Column(nullable = false)
-    @Builder.Default
     private Integer headcount = 0;
     @Column(nullable = false)
-    @Builder.Default
     private Boolean isVisible = false;
     @Column(nullable = false)
     @Convert(converter = ProgramWayConverter.class)
@@ -64,13 +61,11 @@ public abstract class Program {
     private String zoomLinkPassword;
     @Column(length = 10, nullable = false)
     @Convert(converter = ProgramStatusConverter.class)
-    @Builder.Default
     private ProgramStatus status = ProgramStatus.OPEN;
     @Column(length = 20, nullable = false)
     @Convert(converter = ProgramTypeConverter.class)
     private ProgramType programType;
     @OneToMany(mappedBy = "program", orphanRemoval = true)
-    @Builder.Default
     private List<Application> applicationList = new ArrayList<>();
     @OneToOne
     private Payment payment;

--- a/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/helper/ProgramHelper.java
@@ -1,8 +1,6 @@
 package com.letsintern.letsintern.domain.program.helper;
 
-import com.letsintern.letsintern.domain.program.domain.MailType;
-import com.letsintern.letsintern.domain.program.domain.ProgramStatus;
-import com.letsintern.letsintern.domain.program.domain.Program;
+import com.letsintern.letsintern.domain.program.domain.*;
 import com.letsintern.letsintern.domain.program.dto.request.ProgramRequestDto;
 import com.letsintern.letsintern.domain.program.exception.ProgramNotFound;
 import com.letsintern.letsintern.domain.program.repository.ProgramRepository;
@@ -45,7 +43,7 @@ public class ProgramHelper {
         if (MailType.APPROVED.equals(mailType))
             return emailUtils.getChallengeApprovedEmailText(program);
         else if (MailType.FEE_CONFIRMED.equals(mailType))
-            return emailUtils.getChallengeFeeConfirmedEmailText(program);
+            return emailUtils.getChallengeFeeConfirmedEmailText((Challenge) program);
         else
             return null;
     }
@@ -66,5 +64,9 @@ public class ProgramHelper {
 
     public void saveProgram(Program program) {
         programRepository.save(program);
+    }
+
+    public Page<Program> findAllProgramByTypeAndTh(ProgramRequestType type, Integer th, Pageable pageable) {
+        return programRepository.findAllProgramByTypeAndTh(type, th, pageable);
     }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/program/repository/ProgramQueryRepository.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/repository/ProgramQueryRepository.java
@@ -1,8 +1,9 @@
 package com.letsintern.letsintern.domain.program.repository;
 
 import com.letsintern.letsintern.domain.program.domain.Program;
+import com.letsintern.letsintern.domain.program.domain.ProgramRequestType;
+import com.letsintern.letsintern.domain.program.domain.ProgramType;
 import com.letsintern.letsintern.domain.program.vo.program.ProgramDetailVo;
-import com.letsintern.letsintern.domain.program.vo.program.UserProgramVo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -14,5 +15,5 @@ public interface ProgramQueryRepository {
     Optional<ProgramDetailVo> findProgramDetailVo(Long programId);
     void updateAllProgramStatusClosedByDueDate(LocalDateTime now);
     List<Long> findAllProgramIdListAndUpdateStatusToDone(LocalDateTime now);
-    Page<Program> findAllAdminByTypeAndTh(String type, Integer th, Pageable pageable);
+    Page<Program> findAllProgramByTypeAndTh(ProgramRequestType type, Integer th, Pageable pageable);
 }

--- a/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramSpecificService.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/service/ProgramSpecificService.java
@@ -13,10 +13,7 @@ import com.letsintern.letsintern.domain.mission.vo.MissionDashboardVo;
 import com.letsintern.letsintern.domain.mission.vo.MissionMyDashboardVo;
 import com.letsintern.letsintern.domain.notice.domain.Notice;
 import com.letsintern.letsintern.domain.notice.helper.NoticeHelper;
-import com.letsintern.letsintern.domain.program.domain.Challenge;
-import com.letsintern.letsintern.domain.program.domain.MailType;
-import com.letsintern.letsintern.domain.program.domain.Program;
-import com.letsintern.letsintern.domain.program.domain.ProgramStatus;
+import com.letsintern.letsintern.domain.program.domain.*;
 import com.letsintern.letsintern.domain.program.dto.response.*;
 import com.letsintern.letsintern.domain.program.helper.ProgramHelper;
 import com.letsintern.letsintern.domain.program.mapper.ProgramMapper;
@@ -115,5 +112,10 @@ public class ProgramSpecificService {
             return null;
         else
             return attendanceHelper.getYesterdayHeadCount(program.getId(), dailyMission.getTh() - 1, AttendanceStatus.PRESENT, AttendanceResult.PASS);
+    }
+
+    public ProgramListResponseDto<?> getProgramAdminList(ProgramRequestType type, Integer th, Pageable pageable) {
+        Page<Program> programPage = programHelper.findAllProgramByTypeAndTh(type, th, pageable);
+        return programMapper.toProgramListResponseDto(programPage);
     }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/user/filter/UserFilter.java
+++ b/src/main/java/com/letsintern/letsintern/domain/user/filter/UserFilter.java
@@ -47,10 +47,10 @@ public class UserFilter {
 
         BooleanBuilder booleanBuilder = new BooleanBuilder();
         if(programTh == null) {
-            booleanBuilder.and(qApplication.program.type.eq(programType))
+            booleanBuilder.and(qApplication.program.programType.eq(programType))
                     .and(qApplication.program.th.eq(programTh));
         } else {
-            booleanBuilder.and(qApplication.program.type.eq(programType));
+            booleanBuilder.and(qApplication.program.programType.eq(programType));
         }
 
         return booleanBuilder;

--- a/src/main/java/com/letsintern/letsintern/global/common/util/EmailUtils.java
+++ b/src/main/java/com/letsintern/letsintern/global/common/util/EmailUtils.java
@@ -1,9 +1,6 @@
 package com.letsintern.letsintern.global.common.util;
 
-import com.letsintern.letsintern.domain.program.domain.LetsChat;
-import com.letsintern.letsintern.domain.program.domain.Program;
-import com.letsintern.letsintern.domain.program.domain.ProgramType;
-import com.letsintern.letsintern.domain.program.domain.ProgramWay;
+import com.letsintern.letsintern.domain.program.domain.*;
 import com.letsintern.letsintern.domain.program.vo.ProgramEmailVo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.MessageSource;
@@ -130,11 +127,11 @@ public class EmailUtils {
                 "챌린지는 동기부여를 위한 보증금과 함께\n" +
                 "현직자 연사 초청 및 네트워킹 마련 등을 위한 운영비를 받고 있습니다.\n\n" +
 
-                "본격적인 안내에 앞서 " + (program.getFeeCharge() + program.getFeeRefund()) + "원을 입금 부탁 드립니다.\n" +
+                "본격적인 안내에 앞서 " + (program.getPayment().getFeeCharge() + program.getPayment().getFeeRefund()) + "원을 입금 부탁 드립니다.\n" +
                 "이때 입금주 명은 신청인 이름과 동일하게 설정해 주세요.\n\n" +
 
-                "\uD83C\uDFE6 계좌 : " + program.getAccountType().getValue() + " " + program.getAccountNumber() + "\n" +
-                "\uD83D\uDCC5 기한 : " + StringUtils.dateToString(program.getFeeDueDate()) + "까지\n\n" +
+                "\uD83C\uDFE6 계좌 : " + program.getPayment().getAccountType().getValue() + " " + program.getPayment().getAccountNumber() + "\n" +
+                "\uD83D\uDCC5 기한 : " + StringUtils.dateToString(program.getPayment().getFeeDueDate()) + "까지\n\n" +
 
                 "입금 기한 직후, 입금이 확인된 인원을 대상으로\n" +
                 "오픈채팅방 및 온라인 OT 참여 링크, 챌린지 대시보드 접속 안내 등의 공지를 드립니다.\n\n" +
@@ -144,17 +141,17 @@ public class EmailUtils {
     }
 
     /* 챌린지 - 참여 확정 안내 메일 TEXT */
-    public String getChallengeFeeConfirmedEmailText(Program program) {
+    public String getChallengeFeeConfirmedEmailText(Challenge challenge) {
         final String HEADER = messageSource.getMessage("mail.lets-chat.header", null, null);
         final String FOOTER = messageSource.getMessage("mail.lets-chat.footer", null, null);
 
-        return "[렛츠인턴] " + program.getTitle() + " 참여 확정 공지\n\n" +
+        return "[렛츠인턴] " + challenge.getTitle() + " 참여 확정 공지\n\n" +
                 HEADER +
-                "드디어 내일(" + StringUtils.dateToStringMMdd(program.getStartDate()) + ") OT와 함께 " + program.getTitle() + "가 시작합니다!\n" +
+                "드디어 내일(" + StringUtils.dateToStringMMdd(challenge.getStartDate()) + ") OT와 함께 " + challenge.getTitle() + "가 시작합니다!\n" +
                 "챌린지 참여에 핵심이 될 공지를 몇가지 드리려 합니다.\n" +
                 "안내 사항에 따라 설정 및 접속 부탁 드리겠습니다.\n\n" +
 
-                "[1] 챌린지 " + program.getTitle() + "기 카카오톡 오픈 채팅방에 들어와 주세요!\n" +
+                "[1] 챌린지 " + challenge.getTitle() + "기 카카오톡 오픈 채팅방에 들어와 주세요!\n" +
                 "참여자들 간의 소통이 이루어지는 공간입니다.\n" +
 
                 "이때 카카오프렌즈 프로필이 아닌 \"새로운 오픈 프로필 만들기\"로 가입해주세요!\n" +
@@ -167,14 +164,14 @@ public class EmailUtils {
 
                 "채팅 설정은 한번 프로필을 만든 후에는 수정이 어려워,\n" +
                 "다시 만들어야 한다는 번거로움이 있어 상기 조건을 한번 더 확인해 주세요.\n" +
-                "\uD83D\uDD17 링크: " + program.getOpenKakaoLink() + " \n" +
-                "\uD83D\uDD10 비밀번호 : " + program.getOpenKakaoPassword() + "\n\n" +
+                "\uD83D\uDD17 링크: " + challenge.getOpenKakaoLink() + " \n" +
+                "\uD83D\uDD10 비밀번호 : " + challenge.getOpenKakaoPassword() + "\n\n" +
 
-                "[2] OT는 온라인으로 " + StringUtils.dateToStringMMddEaHHmm(program.getStartDate()) + "에 진행됩니다.\n" +
+                "[2] OT는 온라인으로 " + StringUtils.dateToStringMMddEaHHmm(challenge.getStartDate()) + "에 진행됩니다.\n" +
                 "1시간 소요 예정으로 렛츠인턴 소개와 챌린지 운영 방식, 보증금 및 혜택을 안내 드립니다.\n" +
                 "참여하신 분들만을 위해 커리큘럼을 상세하게 설명 드리오니 최대한 참여해 주세요.\n" +
-                "\uD83D\uDD17 링크 : " + program.getLink() + " \n" +
-                "\uD83D\uDD10 비밀번호 : " + program.getLinkPassword() + "\n\n" +
+                "\uD83D\uDD17 링크 : " + challenge.getZoomLink() + " \n" +
+                "\uD83D\uDD10 비밀번호 : " + challenge.getZoomLinkPassword() + "\n\n" +
 
                 "[3] 이번 챌린지는 렛츠인턴 웹사이트에서 콘텐츠 및 미션 공지와 인증이 이루어집니다.\n" +
                 "신청하신 계정의 마이페이지에서 챌린지 대시보드에 바로 접속하실 수 있습니다.\n" +
@@ -182,7 +179,7 @@ public class EmailUtils {
                 "\uD83D\uDD17 링크 : https://www.letsintern.co.kr/ \n" +
                 "\uD83D\uDC49 방법 : 로그인 후 마이페이지 → 신청 현황 → 참여 중 섹션 → 챌린지로 이동 클릭\n\n" +
 
-                program.getTitle() + "에 함께 하게 되신 걸 다시 한번 환영합니다.\n" +
+                challenge.getTitle() + "에 함께 하게 되신 걸 다시 한번 환영합니다.\n" +
                 "모두 내일 OT에서 만나요 \uD83D\uDE0A \n\n" +
                 FOOTER;
     }


### PR DESCRIPTION
## 🟪 관련 이슈

- close #146 

## 🟪 작업 내용

- [x] QProgram 다운캐스팅
- [x] Program Admin Filtered List API
- [x] BannerServiceFactoryConfig - ServiceFactoryConfig 빈 이름 겹침 이슈 해결

## 🟪 PR Point 

- topic 등의 정보는 Challenge에서만 조회 가능하므로 QProgram을 QChallenge로 다운캐스팅하도록 RepositoryQueryImpl을 수정하였습니다
- BooleanBuilder를 이용하여 programType, th로 필터링한 프로그램 전체 목록 조회 API를 구현하였습니다.
- banner 패키지의 ServiceFactoryConfig과 program 패키지의 ServiceFactoryConfig 빈 이름이 겹치는 이슈가 있어, banner쪽 빈 이름을 bannerServiceFactoryConfig로 수정하였습니다.
