### PR TITLE
Feature/175 refactor

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,107 +1,107 @@
-name: Deploy to EC2
-
-on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    branches:
-      - dev
-
-permissions:
-  contents: read
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      # 기본 체크아웃
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      # JDK version 설정
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      # Gradlew Permission
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      # Gradle Caching
-      - name: Gradle Caching
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-
-      ## Make application-secret.yml
-      - name: Make application-secret.yml
-        run: |
-          touch ./src/main/resources/application-dev.yml
-          echo "${{ secrets.APPLICATION_SECRET_DEV }}" > ./src/main/resources/application-dev.yml
-        env:
-          PROPERTIES_DEV: ${{ secrets.APPLICATION_SECRET_DEV }}
-
-      # Build with Gradle
-      - name: Build with Gradle
-        run: ./gradlew build -x test
-
-      - name: Docker meta
-        id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
-        with:
-          images: letsintern/letsintern-server-dev
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Docker build & push
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
-
-      - name: create remote directory
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST_DEV }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY_DEV }}
-          script: mkdir -p ~/srv/ubuntu/letsintern-server-dev
-
-      - name: copy source via ssh key
-        uses: burnett01/rsync-deployments@4.1
-        with:
-          switches: -avzr --delete
-          remote_path: ~/srv/ubuntu/
-          remote_host: ${{ secrets.EC2_HOST_DEV }}
-          remote_user: ubuntu
-          remote_key: ${{ secrets.EC2_KEY_DEV }}
-
-      - name: executing remote ssh commands using password
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST_DEV }}
-          username: ubuntu
-          key: ${{ secrets.EC2_KEY_DEV }}
-          script: |
-            sudo docker rm -f $(docker ps -qa)
-            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
-            sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
-            sudo docker image prune -f
+#name: Deploy to EC2
+#
+#on:
+#  push:
+#    branches:
+#      - dev
+#  pull_request:
+#    branches:
+#      - dev
+#
+#permissions:
+#  contents: read
+#
+#jobs:
+#  build:
+#    runs-on: ubuntu-latest
+#    steps:
+#      # 기본 체크아웃
+#      - name: Checkout
+#        uses: actions/checkout@v3
+#
+#      # JDK version 설정
+#      - name: Set up JDK 17
+#        uses: actions/setup-java@v3
+#        with:
+#          java-version: '17'
+#          distribution: 'temurin'
+#
+#      # Gradlew Permission
+#      - name: Grant execute permission for gradlew
+#        run: chmod +x gradlew
+#
+#      # Gradle Caching
+#      - name: Gradle Caching
+#        uses: actions/cache@v3
+#        with:
+#          path: |
+#            ~/.gradle/caches
+#            ~/.gradle/wrapper
+#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#          restore-keys: |
+#            ${{ runner.os }}-gradle-
+#
+#      ## Make application-secret.yml
+#      - name: Make application-secret.yml
+#        run: |
+#          touch ./src/main/resources/application-dev.yml
+#          echo "${{ secrets.APPLICATION_SECRET_DEV }}" > ./src/main/resources/application-dev.yml
+#        env:
+#          PROPERTIES_DEV: ${{ secrets.APPLICATION_SECRET_DEV }}
+#
+#      # Build with Gradle
+#      - name: Build with Gradle
+#        run: ./gradlew build -x test
+#
+#      - name: Docker meta
+#        id: docker_meta
+#        uses: crazy-max/ghaction-docker-meta@v1
+#        with:
+#          images: letsintern/letsintern-server-dev
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
+#
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+#
+#      - name: Docker build & push
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: .
+#          file: ./Dockerfile
+#          platforms: linux/amd64
+#          push: true
+#          tags: ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
+#
+#      - name: create remote directory
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.EC2_HOST_DEV }}
+#          username: ubuntu
+#          key: ${{ secrets.EC2_KEY_DEV }}
+#          script: mkdir -p ~/srv/ubuntu/letsintern-server-dev
+#
+#      - name: copy source via ssh key
+#        uses: burnett01/rsync-deployments@4.1
+#        with:
+#          switches: -avzr --delete
+#          remote_path: ~/srv/ubuntu/
+#          remote_host: ${{ secrets.EC2_HOST_DEV }}
+#          remote_user: ubuntu
+#          remote_key: ${{ secrets.EC2_KEY_DEV }}
+#
+#      - name: executing remote ssh commands using password
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.EC2_HOST_DEV }}
+#          username: ubuntu
+#          key: ${{ secrets.EC2_KEY_DEV }}
+#          script: |
+#            sudo docker rm -f $(docker ps -qa)
+#            sudo docker pull ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
+#            sudo docker run -d -p 8080:8080 ${{ secrets.DOCKER_USERNAME }}/letsintern-server-dev
+#            sudo docker image prune -f

--- a/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
@@ -69,7 +69,7 @@ public class AttendanceHelper {
         return attendance;
     }
 
-    public Integer getYesterdayHeadCount(Long programId, Integer missionTh, AttendanceStatus attendanceStatus, AttendanceResult attendanceResult) {
+    public Integer getPreviousHeadCount(Long programId, Integer missionTh, AttendanceStatus attendanceStatus, AttendanceResult attendanceResult) {
         return attendanceRepository.countAllByMissionProgramIdAndMissionThAndStatusAndResult(programId, missionTh, attendanceStatus, attendanceResult);
     }
 

--- a/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/attendance/helper/AttendanceHelper.java
@@ -58,11 +58,14 @@ public class AttendanceHelper {
     public Attendance updateAttendance(Long attendanceId, AttendanceBaseDTO attendanceUpdateDTO, Long userId) {
         Attendance attendance = attendanceRepository.findById(attendanceId).orElseThrow(() -> AttendanceNotFound.EXCEPTION);
         if(!Objects.equals(attendance.getUser().getId(), userId)) throw ApplicationUnauthorized.EXCEPTION;
-        if(!isEditableAttendance(attendance.getMission())) throw AttendanceCannotUpdated.EXCEPTION;
-        else if(attendanceUpdateDTO.getLink() != null) {
+
+        if(attendanceUpdateDTO.getLink() != null) {
+            if(isEditableAttendance(attendance.getMission())) {
+                attendance.setStatus(AttendanceStatus.UPDATED);
+            } else {
+                attendance.setStatus(AttendanceStatus.LATE);
+            }
             attendance.setLink(attendanceUpdateDTO.getLink());
-            attendance.setStatus(AttendanceStatus.UPDATED);
-            attendance.setResult(AttendanceResult.WAITING);
             attendance.setComments(null);
         }
 

--- a/src/main/java/com/letsintern/letsintern/domain/mission/domain/Mission.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/domain/Mission.java
@@ -87,8 +87,9 @@ public class Mission {
     private List<Attendance> attendanceList;
 
     @Builder
-    private Mission(Program program, MissionTopic topic, MissionType type, Integer refund, String title, String contents, String guide, Integer th, String template,
-                    String comments, Contents essentialContents, Contents additionalContents, Contents limitedContents) {
+    private Mission(Program program, MissionTopic topic, MissionType type, Integer refund, String title, String contents, String guide,
+                    Integer th, LocalDateTime startDate, LocalDateTime endDate,
+                    String template, String comments, Contents essentialContents, Contents additionalContents, Contents limitedContents) {
         this.program = program;
         this.type = type;
         this.topic = topic;
@@ -101,9 +102,8 @@ public class Mission {
         this.guide = guide;
 
         this.th = th;
-        if(th == 1) this.startDate = program.getStartDate();
-        else this.startDate = program.getStartDate().plusDays(th - 1).withHour(6);
-        this.endDate = this.startDate.withHour(23).withMinute(59).withSecond(59);
+        this.startDate = startDate;
+        this.endDate = endDate;
 
         this.template = template;
         this.comments = comments;
@@ -123,6 +123,8 @@ public class Mission {
                 .contents(missionCreateDTO.getContents())
                 .guide(missionCreateDTO.getGuide())
                 .th(missionCreateDTO.getTh())
+                .startDate(missionCreateDTO.getStartDate())
+                .endDate(missionCreateDTO.getEndDate())
                 .template(missionCreateDTO.getTemplate())
                 .comments(missionCreateDTO.getComments())
                 .essentialContents(essentialContents)

--- a/src/main/java/com/letsintern/letsintern/domain/mission/dto/request/MissionCreateDTO.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/dto/request/MissionCreateDTO.java
@@ -7,6 +7,7 @@ import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
@@ -32,6 +33,12 @@ public class MissionCreateDTO {
 
     @NotNull
     private Integer th;
+
+    @NotNull
+    private LocalDateTime startDate;
+
+    @NotNull
+    private LocalDateTime endDate;
 
     @NotNull
     private String template;

--- a/src/main/java/com/letsintern/letsintern/domain/mission/dto/request/MissionUpdateDTO.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/dto/request/MissionUpdateDTO.java
@@ -6,6 +6,8 @@ import com.letsintern.letsintern.domain.mission.domain.MissionTopic;
 import com.letsintern.letsintern.domain.mission.domain.MissionType;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 public class MissionUpdateDTO {
 
@@ -24,6 +26,10 @@ public class MissionUpdateDTO {
     private String guide;
 
     private Integer th;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
 
     private String template;
 

--- a/src/main/java/com/letsintern/letsintern/domain/mission/dto/response/MissionAdminSimpleListResponse.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/dto/response/MissionAdminSimpleListResponse.java
@@ -4,9 +4,7 @@ import com.letsintern.letsintern.domain.mission.vo.MissionAdminSimpleVo;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.util.List;
 
 @Getter
@@ -17,20 +15,20 @@ public class MissionAdminSimpleListResponse {
     private List<MissionAdminSimpleVo> missionList;
 
     @Builder
-    private MissionAdminSimpleListResponse(Integer finalHeadCount, LocalDateTime startDate, List<MissionAdminSimpleVo> missionList) {
+    private MissionAdminSimpleListResponse(Integer finalHeadCount, List<MissionAdminSimpleVo> missionList) {
         this.finalHeadCount = finalHeadCount;
 
-        LocalDate today = LocalDate.now();
-        int diffDays = Period.between(LocalDate.from(startDate), today).getDays() + 1;
-        if(diffDays >= 1 && diffDays <= 14) this.currentTh = diffDays;
+        LocalDateTime now = LocalDateTime.now();
+        missionList.stream()
+                .filter(mission -> mission.getMissionStartDate().isBefore(now) && mission.getMissionEndDate().isAfter(now))
+                .findFirst().ifPresent(missionAdminSimpleVo -> this.currentTh = missionAdminSimpleVo.getMissionTh());
 
         this.missionList = missionList;
     }
 
-    public static MissionAdminSimpleListResponse of(Integer finalHeadCount, LocalDateTime startDate, List<MissionAdminSimpleVo> missionList) {
+    public static MissionAdminSimpleListResponse of(Integer finalHeadCount, List<MissionAdminSimpleVo> missionList) {
         return MissionAdminSimpleListResponse.builder()
                 .finalHeadCount(finalHeadCount)
-                .startDate(startDate)
                 .missionList(missionList)
                 .build();
     }

--- a/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
@@ -141,22 +141,12 @@ public class MissionHelper {
         missionRepository.delete(mission);
     }
 
-    public MissionDashboardVo getDailyMission(Long programId, LocalDateTime startDate) {
-        LocalDate today = LocalDate.now();
-        Period period = Period.between(LocalDate.from(startDate), today);
-
-        int currentHour = LocalDateTime.now().getHour();
-        if(currentHour < 6) return missionRepository.getMissionDashboardVo(programId, period.getDays()).orElse(null);
-        return missionRepository.getMissionDashboardVo(programId, period.getDays() + 1).orElse(null);
+    public MissionDashboardVo getDailyMission(Long programId) {
+        return missionRepository.getDailyMission(programId).orElse(null);
     }
 
-    public MissionMyDashboardVo getDailyMissionDetail(Long programId, LocalDateTime startDate, Long userId) {
-        LocalDate today = LocalDate.now();
-        Period period = Period.between(LocalDate.from(startDate), today);
-
-        int currentHour = LocalDateTime.now().getHour();
-        if(currentHour < 6) return missionRepository.getMissionMyDashboardVo(programId, period.getDays(), userId).orElse(null);
-        return missionRepository.getMissionMyDashboardVo(programId, period.getDays() + 1, userId).orElse(null);
+    public MissionMyDashboardVo getDailyMissionDetail(Long programId, Long userId) {
+        return missionRepository.getDailyMissionDetail(programId, userId).orElse(null);
     }
 
     public List<MissionDashboardListVo> getMissionDashboardList(Long programId, Long userId) {

--- a/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/helper/MissionHelper.java
@@ -98,12 +98,12 @@ public class MissionHelper {
             mission.setContents(missionUpdateDTO.getContents());
         if(missionUpdateDTO.getGuide() != null)
             mission.setGuide(missionUpdateDTO.getGuide());
-        if(missionUpdateDTO.getTh() != null) {
+        if(missionUpdateDTO.getTh() != null)
             mission.setTh(missionUpdateDTO.getTh());
-            if(missionUpdateDTO.getTh() == 1) mission.setStartDate(mission.getProgram().getStartDate());
-            else mission.setStartDate(mission.getProgram().getStartDate().plusDays(missionUpdateDTO.getTh() - 1).withHour(6));
-            mission.setEndDate(mission.getStartDate().withHour(23).withMinute(59).withSecond(59));
-        }
+        if(missionUpdateDTO.getStartDate() != null)
+            mission.setStartDate(missionUpdateDTO.getStartDate());
+        if(missionUpdateDTO.getEndDate() != null)
+            mission.setEndDate(missionUpdateDTO.getEndDate());
         if(missionUpdateDTO.getTemplate() != null)
             mission.setTemplate(missionUpdateDTO.getTemplate());
         if(missionUpdateDTO.getComments() != null)

--- a/src/main/java/com/letsintern/letsintern/domain/mission/mapper/MissionMapper.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/mapper/MissionMapper.java
@@ -28,8 +28,8 @@ public class MissionMapper {
         return MissionIdResponse.from(missionId);
     }
 
-    public MissionAdminSimpleListResponse toMissionAdminSimpleListResponse(Integer finalHeadCount, LocalDateTime startDate, List<MissionAdminSimpleVo> missionAdminSimpleList) {
-        return MissionAdminSimpleListResponse.of(finalHeadCount, startDate, missionAdminSimpleList);
+    public MissionAdminSimpleListResponse toMissionAdminSimpleListResponse(Integer finalHeadCount, List<MissionAdminSimpleVo> missionAdminSimpleList) {
+        return MissionAdminSimpleListResponse.of(finalHeadCount, missionAdminSimpleList);
     }
 
     public MissionAdminListResponse toMissionAdminListResponse(Page<MissionAdminVo> missionAdminList) {

--- a/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryCustom.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryCustom.java
@@ -15,10 +15,6 @@ public interface MissionRepositoryCustom {
 
     List<MissionAdminSimpleVo> getMissionAdminSimpleList(Long programId);
 
-    Optional<MissionDashboardVo> getMissionDashboardVo(Long programId, Integer th);
-
-    Optional<MissionMyDashboardVo> getMissionMyDashboardVo(Long programId, Integer th, Long userId);
-
     List<MissionDashboardListVo> getMissionDashboardList(Long programId, Long userId);
 
     List<MissionMyDashboardListVo> getMissionMyDashboardList(Long programId, Long userId);
@@ -30,4 +26,8 @@ public interface MissionRepositoryCustom {
     Optional<MissionMyDashboardAbsentVo> getMissionMyDashboardAbsentVo(Long missionId, Long userId);
 
     List<MissionAdminApplicationVo> getMissionAdminApplicationVos(Long programId, Long userId);
+
+    Optional<MissionDashboardVo> getDailyMission(Long programId);
+
+    Optional<MissionMyDashboardVo> getDailyMissionDetail(Long programId, Long userId);
 }

--- a/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
@@ -1,10 +1,9 @@
 package com.letsintern.letsintern.domain.mission.repository;
 
-import com.letsintern.letsintern.domain.attendance.domain.QAttendance;
 import com.letsintern.letsintern.domain.contents.domain.QContents;
-import com.letsintern.letsintern.domain.mission.domain.QMission;
 import com.letsintern.letsintern.domain.mission.vo.*;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +12,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static com.letsintern.letsintern.domain.attendance.domain.QAttendance.attendance;
+import static com.letsintern.letsintern.domain.contents.domain.QContents.contents;
+import static com.letsintern.letsintern.domain.mission.domain.QMission.mission;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,294 +28,292 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
 
     @Override
     public Page<MissionAdminVo> getMissionAdminList(Long programId, Pageable pageable) {
-        QMission qMission = QMission.mission;
-        QContents qContents = QContents.contents;
         List<MissionAdminVo> missionAdminVos;
         JPAQuery<Long> count;
 
         missionAdminVos = jpaQueryFactory
                 .select(Projections.constructor(MissionAdminVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.type,
-                        qMission.refund,
-                        qMission.title,
-                        qMission.startDate,
-                        qMission.endDate,
-                        qMission.status,
-                        qContents.topic,
-                        qMission.attendanceCount,
-                        qMission.lateAttendanceCount,
-                        qMission.program.finalHeadCount))
-                .from(qMission)
-                .leftJoin(qContents)
+                        mission.id,
+                        mission.th,
+                        mission.type,
+                        mission.refund,
+                        mission.title,
+                        mission.startDate,
+                        mission.endDate,
+                        mission.status,
+                        contents.topic,
+                        mission.attendanceCount,
+                        mission.lateAttendanceCount,
+                        mission.program.finalHeadCount))
+                .from(mission)
+                .leftJoin(contents)
                 .on(
-                        qMission.essentialContentsId.eq(qContents.id)
+                        mission.essentialContentsId.eq(contents.id)
                 )
-                .where(qMission.program.id.eq(programId))
-                .orderBy(qMission.th.asc())
+                .where(mission.program.id.eq(programId))
+                .orderBy(mission.th.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        count = jpaQueryFactory.select(qMission.count())
-                .from(qMission)
-                .where(qMission.program.id.eq(programId));
+        count = jpaQueryFactory.select(mission.count())
+                .from(mission)
+                .where(mission.program.id.eq(programId));
 
         return PageableExecutionUtils.getPage(missionAdminVos, pageable, count::fetchOne);
     }
 
     @Override
     public Optional<MissionAdminDetailVo> getMissionAdminDetailVo(Long missionId) {
-        QMission qMission = QMission.mission;
         QContents qEssentialContents = new QContents("essential");
         QContents qAdditionalContents = new QContents("additional");
         QContents qLimitedContents = new QContents("limited");
 
         return Optional.ofNullable(jpaQueryFactory
                 .select(Projections.constructor(MissionAdminDetailVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.type,
-                        qMission.topic,
-                        qMission.status,
-                        qMission.title,
-                        qMission.contents,
-                        qMission.guide,
-                        qMission.template,
-                        qMission.comments,
-                        qMission.startDate,
-                        qMission.endDate,
-                        qMission.refund,
-                        qMission.program.feeRefund,
+                        mission.id,
+                        mission.th,
+                        mission.type,
+                        mission.topic,
+                        mission.status,
+                        mission.title,
+                        mission.contents,
+                        mission.guide,
+                        mission.template,
+                        mission.comments,
+                        mission.startDate,
+                        mission.endDate,
+                        mission.refund,
+                        mission.program.feeRefund,
                         qEssentialContents.topic,
                         qAdditionalContents.topic,
                         qLimitedContents.topic))
-                .from(qMission)
+                .from(mission)
                         .leftJoin(qEssentialContents)
-                        .on(qMission.essentialContentsId.eq(qEssentialContents.id))
+                        .on(mission.essentialContentsId.eq(qEssentialContents.id))
                         .leftJoin(qAdditionalContents)
-                        .on(qMission.additionalContentsId.eq(qAdditionalContents.id))
+                        .on(mission.additionalContentsId.eq(qAdditionalContents.id))
                         .leftJoin(qLimitedContents)
-                        .on(qMission.limitedContentsId.eq(qLimitedContents.id))
-                .where(qMission.id.eq(missionId))
+                        .on(mission.limitedContentsId.eq(qLimitedContents.id))
+                .where(mission.id.eq(missionId))
                 .fetchFirst());
     }
 
     @Override
     public List<MissionAdminSimpleVo> getMissionAdminSimpleList(Long programId) {
-        QMission qMission = QMission.mission;
         return jpaQueryFactory
                 .select(Projections.constructor(MissionAdminSimpleVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.startDate,
-                        qMission.endDate,
-                        qMission.attendanceCount,
-                        qMission.lateAttendanceCount,
-                        qMission.status))
-                .from(qMission)
-                .where(qMission.program.id.eq(programId))
-                .orderBy(qMission.th.asc())
+                        mission.id,
+                        mission.th,
+                        mission.startDate,
+                        mission.endDate,
+                        mission.attendanceCount,
+                        mission.lateAttendanceCount,
+                        mission.status))
+                .from(mission)
+                .where(mission.program.id.eq(programId))
+                .orderBy(mission.th.asc())
                 .fetch();
     }
 
     @Override
-    public Optional<MissionDashboardVo> getMissionDashboardVo(Long programId, Integer th) {
-        QMission qMission = QMission.mission;
-        return Optional.ofNullable(jpaQueryFactory
-                .select(Projections.constructor(MissionDashboardVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.title,
-                        qMission.contents,
-                        qMission.endDate))
-                .from(qMission)
-                .where(qMission.program.id.eq(programId).and(qMission.th.eq(th)))
-                .fetchFirst());
-    }
-
-    @Override
-    public Optional<MissionMyDashboardVo> getMissionMyDashboardVo(Long programId, Integer th, Long userId) {
-        QMission qMission = QMission.mission;
-        QContents qEssentialContents = new QContents("essential");
-        QContents qAdditionalContents = new QContents("additional");
-        QAttendance qAttendance = QAttendance.attendance;
-        return Optional.ofNullable(jpaQueryFactory
-                .select(Projections.constructor(MissionMyDashboardVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.title,
-                        qMission.contents,
-                        qMission.guide,
-                        qMission.template,
-                        qMission.endDate,
-                        qEssentialContents.link,
-                        qAdditionalContents.link,
-                        qAttendance))
-                .from(qMission)
-                .leftJoin(qAttendance)
-                .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId)
-                )
-                .leftJoin(qEssentialContents)
-                .on(qEssentialContents.id.eq(qMission.essentialContentsId))
-                .leftJoin(qAdditionalContents)
-                .on(qAdditionalContents.id.eq(qMission.additionalContentsId))
-                .where(qMission.program.id.eq(programId).and(qMission.th.eq(th)))
-                .fetchFirst());
-    }
-
-    @Override
     public List<MissionDashboardListVo> getMissionDashboardList(Long programId, Long userId) {
-        QMission qMission = QMission.mission;
-        QAttendance qAttendance = QAttendance.attendance;
-
         return jpaQueryFactory
                 .select(Projections.constructor(MissionDashboardListVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.topic,
-                        qMission.type,
-                        qMission.startDate,
-                        qMission.comments,
-                        qMission.refund,
-                        qAttendance))
-                .from(qMission)
-                .leftJoin(qAttendance)
+                        mission.id,
+                        mission.th,
+                        mission.topic,
+                        mission.type,
+                        mission.startDate,
+                        mission.endDate,
+                        mission.comments,
+                        mission.refund,
+                        attendance))
+                .from(mission)
+                .leftJoin(attendance)
                 .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId)
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId)
                 )
-                .where(qMission.program.id.eq(programId))
-                .orderBy(qMission.th.asc())
+                .where(mission.program.id.eq(programId))
+                .orderBy(mission.th.asc())
                 .fetch();
     }
 
     @Override
     public List<MissionMyDashboardListVo> getMissionMyDashboardList(Long programId, Long userId) {
-        QMission qMission = QMission.mission;
-        QAttendance qAttendance = QAttendance.attendance;
         return jpaQueryFactory
                 .select(Projections.constructor(MissionMyDashboardListVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.title,
-                        qMission.status,
-                        qMission.type,
-                        qAttendance))
-                .from(qMission)
-                .leftJoin(qAttendance)
+                        mission.id,
+                        mission.th,
+                        mission.title,
+                        mission.status,
+                        mission.type,
+                        attendance))
+                .from(mission)
+                .leftJoin(attendance)
                 .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId)
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId)
                 )
-                .where(qMission.program.id.eq(programId))
-                .orderBy(qMission.th.desc())
+                .where(mission.program.id.eq(programId))
+                .orderBy(mission.th.desc())
                 .fetch();
     }
 
     @Override
     public Optional<MissionMyDashboardDoneVo> getMissionMyDashboardDoneVo(Long missionId, Long userId) {
-        QMission qMission = QMission.mission;
-        QAttendance qAttendance = QAttendance.attendance;
         QContents qEssentialContents = new QContents("essential");
         QContents qAdditionalContents = new QContents("additional");
         QContents qLimitedContents = new QContents("limited");
 
         return Optional.ofNullable(jpaQueryFactory
                 .select(Projections.constructor(MissionMyDashboardDoneVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.type,
-                        qMission.title,
-                        qMission.contents,
+                        mission.id,
+                        mission.th,
+                        mission.type,
+                        mission.title,
+                        mission.contents,
                         qEssentialContents.link,
                         qAdditionalContents.link,
                         qLimitedContents.link,
-                        qMission.comments,
-                        qAttendance))
-                .from(qMission)
-                .leftJoin(qAttendance)
+                        mission.comments,
+                        attendance))
+                .from(mission)
+                .leftJoin(attendance)
                 .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId)
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId)
                 )
                 .leftJoin(qEssentialContents)
-                .on(qMission.essentialContentsId.eq(qEssentialContents.id))
+                .on(mission.essentialContentsId.eq(qEssentialContents.id))
                 .leftJoin(qAdditionalContents)
-                .on(qMission.additionalContentsId.eq(qAdditionalContents.id))
+                .on(mission.additionalContentsId.eq(qAdditionalContents.id))
                 .leftJoin(qLimitedContents)
-                .on(qMission.limitedContentsId.eq(qLimitedContents.id))
-                .where(qMission.id.eq(missionId))
+                .on(mission.limitedContentsId.eq(qLimitedContents.id))
+                .where(mission.id.eq(missionId))
                 .fetchFirst());
     }
 
     @Override
     public Optional<MissionMyDashboardYetVo> getMissionMyDashboardYetVo(Long missionId) {
-        QMission qMission = QMission.mission;
-
         return Optional.ofNullable(jpaQueryFactory
                 .select(Projections.constructor(MissionMyDashboardYetVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.title,
-                        qMission.contents,
-                        qMission.guide))
-                .from(qMission)
-                .where(qMission.id.eq(missionId))
+                        mission.id,
+                        mission.th,
+                        mission.title,
+                        mission.contents,
+                        mission.guide))
+                .from(mission)
+                .where(mission.id.eq(missionId))
                 .fetchFirst());
     }
 
     @Override
     public Optional<MissionMyDashboardAbsentVo> getMissionMyDashboardAbsentVo(Long missionId, Long userId) {
-        QMission qMission = QMission.mission;
-        QAttendance qAttendance = QAttendance.attendance;
         QContents qEssentialContents = new QContents("essential");
         QContents qAdditionalContents = new QContents("additional");
 
         return Optional.ofNullable(jpaQueryFactory
                 .select(Projections.constructor(MissionMyDashboardAbsentVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qMission.title,
-                        qMission.contents,
-                        qMission.guide,
-                        qMission.template,
+                        mission.id,
+                        mission.th,
+                        mission.title,
+                        mission.contents,
+                        mission.guide,
+                        mission.template,
                         qEssentialContents.link,
                         qAdditionalContents.link,
-                        qAttendance))
-                .from(qMission)
-                .leftJoin(qAttendance)
+                        attendance))
+                .from(mission)
+                .leftJoin(attendance)
                 .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId)
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId)
                 )
                 .leftJoin(qEssentialContents)
-                .on(qMission.essentialContentsId.eq(qEssentialContents.id))
+                .on(mission.essentialContentsId.eq(qEssentialContents.id))
                 .leftJoin(qAdditionalContents)
-                .on(qMission.additionalContentsId.eq(qAdditionalContents.id))
-                .where(qMission.id.eq(missionId).and(qAttendance.isNull()))
+                .on(mission.additionalContentsId.eq(qAdditionalContents.id))
+                .where(mission.id.eq(missionId).and(attendance.isNull()))
                 .fetchFirst());
     }
 
     @Override
     public List<MissionAdminApplicationVo> getMissionAdminApplicationVos(Long programId, Long userId) {
-        QMission qMission = QMission.mission;
-        QAttendance qAttendance = QAttendance.attendance;
-
         return jpaQueryFactory
                 .select(Projections.constructor(MissionAdminApplicationVo.class,
-                        qMission.id,
-                        qMission.th,
-                        qAttendance))
-                .from(qMission)
-                .where(qMission.program.id.eq(programId))
-                .leftJoin(qAttendance)
+                        mission.id,
+                        mission.th,
+                        attendance))
+                .from(mission)
+                .where(mission.program.id.eq(programId))
+                .leftJoin(attendance)
                 .on(
-                        qAttendance.mission.eq(qMission),
-                        qAttendance.user.id.eq(userId))
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId))
                 .fetch();
+    }
+
+    @Override
+    public Optional<MissionDashboardVo> getDailyMission(Long programId) {
+        LocalDateTime now = LocalDateTime.now();
+        return Optional.ofNullable(jpaQueryFactory
+                .select(Projections.constructor(MissionDashboardVo.class,
+                        mission.id,
+                        mission.th,
+                        mission.title,
+                        mission.contents,
+                        mission.endDate))
+                .from(mission)
+                .where(
+                        eqProgramId(programId),
+                        inProgress(now)
+                )
+                .orderBy(mission.id.asc())
+                .fetchOne());
+    }
+
+    @Override
+    public Optional<MissionMyDashboardVo> getDailyMissionDetail(Long programId, Long userId) {
+        QContents qEssentialContents = new QContents("essential");
+        QContents qAdditionalContents = new QContents("additional");
+        LocalDateTime now = LocalDateTime.now();
+
+        return Optional.ofNullable(jpaQueryFactory
+                .select(Projections.constructor(MissionMyDashboardVo.class,
+                        mission.id,
+                        mission.th,
+                        mission.title,
+                        mission.contents,
+                        mission.guide,
+                        mission.template,
+                        mission.endDate,
+                        qEssentialContents.link,
+                        qAdditionalContents.link,
+                        attendance))
+                .from(mission)
+                .leftJoin(attendance)
+                .on(
+                        attendance.mission.eq(mission),
+                        attendance.user.id.eq(userId)
+                )
+                .leftJoin(qEssentialContents)
+                .on(qEssentialContents.id.eq(mission.essentialContentsId))
+                .leftJoin(qAdditionalContents)
+                .on(qAdditionalContents.id.eq(mission.additionalContentsId))
+                .where(
+                        eqProgramId(programId),
+                        inProgress(now)
+                )
+                .fetchFirst());
+    }
+
+    private BooleanExpression eqProgramId(Long programId) {
+        return programId != null ? mission.program.id.eq(programId) : null;
+    }
+
+    private BooleanExpression inProgress(LocalDateTime now) {
+        return mission.startDate.before(now).and(mission.endDate.after(now.minusHours(6)));
     }
 }

--- a/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/repository/MissionRepositoryImpl.java
@@ -106,6 +106,7 @@ public class MissionRepositoryImpl implements MissionRepositoryCustom {
                         qMission.id,
                         qMission.th,
                         qMission.startDate,
+                        qMission.endDate,
                         qMission.attendanceCount,
                         qMission.lateAttendanceCount,
                         qMission.status))

--- a/src/main/java/com/letsintern/letsintern/domain/mission/service/MissionService.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/service/MissionService.java
@@ -36,7 +36,7 @@ public class MissionService {
     @Transactional(readOnly = true)
     public MissionAdminSimpleListResponse getMissionAdminSimpleList(Long programId) {
         final Program program = programRepository.findById(programId).orElseThrow(() -> ProgramNotFound.EXCEPTION);
-        return missionMapper.toMissionAdminSimpleListResponse(program.getFinalHeadCount(), program.getStartDate(), missionHelper.getMissionAdminSimpleList(programId));
+        return missionMapper.toMissionAdminSimpleListResponse(program.getFinalHeadCount(), missionHelper.getMissionAdminSimpleList(programId));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/letsintern/letsintern/domain/mission/vo/MissionAdminSimpleVo.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/vo/MissionAdminSimpleVo.java
@@ -15,6 +15,8 @@ public class MissionAdminSimpleVo {
 
     private LocalDateTime missionStartDate;
 
+    private LocalDateTime missionEndDate;
+
     private Integer attendanceCount;
 
     private Integer lateAttendanceCount;
@@ -22,11 +24,12 @@ public class MissionAdminSimpleVo {
     private MissionStatus missionStatus;
 
     @Builder
-    public MissionAdminSimpleVo(Long missionId, Integer missionTh, LocalDateTime missionStartDate,
+    public MissionAdminSimpleVo(Long missionId, Integer missionTh, LocalDateTime missionStartDate, LocalDateTime missionEndDate,
                                 Integer attendanceCount, Integer lateAttendanceCount, MissionStatus missionStatus) {
         this.missionId = missionId;
         this.missionTh = missionTh;
         this.missionStartDate = missionStartDate;
+        this.missionEndDate = missionEndDate;
         this.attendanceCount = attendanceCount;
         this.lateAttendanceCount = lateAttendanceCount;
         this.missionStatus = missionStatus;

--- a/src/main/java/com/letsintern/letsintern/domain/mission/vo/MissionDashboardListVo.java
+++ b/src/main/java/com/letsintern/letsintern/domain/mission/vo/MissionDashboardListVo.java
@@ -24,6 +24,8 @@ public class MissionDashboardListVo {
 
     private LocalDateTime missionStartDate;
 
+    private LocalDateTime missionEndDate;
+
     private String missionComments;
 
     @JsonIgnore
@@ -36,12 +38,14 @@ public class MissionDashboardListVo {
     private Boolean attendanceIsRefunded;
 
     @Builder
-    public MissionDashboardListVo(Long missionId, Integer missionTh, MissionTopic missionTopic, MissionType missionType, LocalDateTime missionStartDate, String missionComments, Integer missionRefund, Attendance attendance) {
+    public MissionDashboardListVo(Long missionId, Integer missionTh, MissionTopic missionTopic, MissionType missionType,
+                                  LocalDateTime missionStartDate, LocalDateTime missionEndDate, String missionComments, Integer missionRefund, Attendance attendance) {
         this.missionId = missionId;
         this.missionTh = missionTh;
         this.missionTopic = missionTopic.getValue();
         this.missionType = missionType;
         this.missionStartDate = missionStartDate;
+        this.missionEndDate = missionEndDate;
         this.missionRefund = missionRefund;
 
         if(attendance != null) {

--- a/src/main/java/com/letsintern/letsintern/domain/program/dto/response/ProgramDashboardResponse.java
+++ b/src/main/java/com/letsintern/letsintern/domain/program/dto/response/ProgramDashboardResponse.java
@@ -26,13 +26,13 @@ public class ProgramDashboardResponse {
 
     private Integer finalHeadCount;
 
-    private Integer yesterdayHeadCount;
+    private Integer previousHeadCount;
 
     private Boolean isDone;
 
     @Builder
     private ProgramDashboardResponse(String userName, MissionDashboardVo dailyMission, Page<Notice> noticeList, List<MissionDashboardListVo> missionList,
-                                     Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
+                                     Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer previousHeadCount, Boolean isDone) {
         this.userName = userName;
         this.dailyMission = dailyMission;
         this.noticeList = (noticeList.hasContent()) ? noticeList.getContent() : new ArrayList<>();
@@ -40,12 +40,12 @@ public class ProgramDashboardResponse {
         this.currentRefund = currentRefund;
         this.totalRefund = totalRefund;
         this.finalHeadCount = finalHeadCount;
-        this.yesterdayHeadCount = yesterdayHeadCount;
+        this.previousHeadCount = previousHeadCount;
         this.isDone = isDone;
     }
 
     public static ProgramDashboardResponse of(String userName, MissionDashboardVo dailyMission, Page<Notice> noticeList, List<MissionDashboardListVo> missionList,
-                                              Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer yesterdayHeadCount, Boolean isDone) {
+                                              Integer totalRefund, Integer currentRefund, Integer finalHeadCount, Integer previousHeadCount, Boolean isDone) {
         return ProgramDashboardResponse.builder()
                 .userName(userName)
                 .dailyMission(dailyMission)
@@ -54,7 +54,7 @@ public class ProgramDashboardResponse {
                 .totalRefund(totalRefund)
                 .currentRefund(currentRefund)
                 .finalHeadCount(finalHeadCount)
-                .yesterdayHeadCount(yesterdayHeadCount)
+                .previousHeadCount(previousHeadCount)
                 .isDone(isDone)
                 .build();
     }


### PR DESCRIPTION
## 🟪 관련 이슈

- close #175 

## 🟪 작업 내용

- [x] 미션 생성 시 startDate, endDate 받게 변경
- [x] 데일리 미션 판별 조건 th -> startDate, endDate 변경
- [x] 지각 제출의 미션 링크 수정 안됨 이슈 해결

## 🟪 PR Point 

- 미션 생성 시 th를 기준으로 startDate, endDate를 자동 설정했던 방식이 아닌, 관리자가 직접 startDate, endDate를 입력하는 방식으로 로직을 변경하였습니다.
- 데일리 미션을 쿼리하는 기준 또한 th에서 startDate, endDate로 변경되었습니다.
- 지각 제출의 미션 링크 수정이 되지 않던 이슈를 해결하였습니다.
