### PR TITLE
[fix] #183 Application preQuestion, applyMotive Size 550으로 수정

### DIFF
--- a/src/main/java/com/letsintern/letsintern/domain/application/domain/Application.java
+++ b/src/main/java/com/letsintern/letsintern/domain/application/domain/Application.java
@@ -39,11 +39,11 @@ public class Application {
     private ApplicationWishJob wishJob;
 
     @NotNull
-    @Size(max = 700)
+    @Size(max = 550)
     private String applyMotive;
 
     @Nullable
-    @Size(max = 300)
+    @Size(max = 550)
     private String preQuestions;
 
     @NotNull


### PR DESCRIPTION
## 🟪 관련 이슈

- close #183 

## 🟪 작업 내용

- [x] Application preQuestion, applyMotive Size 550으로 수정

## 🟪 PR Point 

- Application.preQuestion이 UI 상으로는 최대 500자, 실제 서버에서는 300자 제한으로 차이가 있었습니다.
- 이로 인해 지원서 제출이 불가능하다는 CX 이슈를 해결합니다.